### PR TITLE
Upgrade actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Set up cache for each package
       id: cache-packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./deb-cache
         key: ${{ runner.os }}-deb-${{ hashFiles('package-versions.txt') }}


### PR DESCRIPTION
@eenagy Thanks for making this action.

This change should make the following warning (which shows up when running the action) go away:

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```


