### PR TITLE
Support running inside a container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,6 @@ runs:
 
     - name: Install packages
       run: |
-        sudo dpkg -i ./deb-cache/*.deb || sudo apt-get install -f -y
+        dpkg -i ./deb-cache/*.deb || sudo dpkg -i ./deb-cache/*.deb || apt-get install -f -y || sudo apt-get install -f -y
       shell: bash
 


### PR DESCRIPTION
Supports using the action in a job running in a `container` (https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container).